### PR TITLE
Add missing methods to Method Summary on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ Method summary:
 
 ```ts
 function formatPrivate(privateKey: Bytes, format: 'base58' | 'hex' | 'array' = 'base');
+function getPublicKey(privateKey: Bytes);
 function getAddress(privateKey: Bytes);
+function getAddressFromPublicKey(publicKey: Bytes);
 function signTx(privateKey: Bytes, data: TxData): Promise<[string, string]>;
 function verifyTx(tx: TxData);
-function createTx(from: string, to: string, amount: string, fee: bigint, blockhash: string);
+function createTx(from: string, to: string, amount: string, _fee: bigint, blockhash: string);
 function createTxComplex(address: string, instructions: Instruction[], blockhash: string);
 function defineProgram<T extends Record<string, MethodHint<any>>>;
 function isOnCurve(bytes: Bytes | string);


### PR DESCRIPTION
While learning about this library, I missed some methods for working with public keys. However, when I searched the source code, I found that these methods were already implemented but not listed in the method summary.

This PR lists the `getPublicKey` and `getAddressFromPublicKey` methods. And renames the `createTx` parameter `fee` to `_fee` to correspond with the current source code.