### PR TITLE
feat: getPublicKeyFromAddress helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ import * as sol from 'micro-sol-signer';
 Method summary:
 
 ```ts
-function formatPrivate(privateKey: Bytes, format: 'base58' | 'hex' | 'array' = 'base');
+function formatPrivate(privateKey: Bytes, format: 'base58' | 'hex' | 'array' = 'base58');
 function getPublicKey(privateKey: Bytes);
 function getAddress(privateKey: Bytes);
 function getAddressFromPublicKey(publicKey: Bytes);
+function getPublicKeyFromAddress(address: string)
 function signTx(privateKey: Bytes, data: TxData): Promise<[string, string]>;
 function verifyTx(tx: TxData);
 function createTx(from: string, to: string, amount: bigint | string, blockhash: string);

--- a/src/index.ts
+++ b/src/index.ts
@@ -491,6 +491,10 @@ export function getAddressFromPublicKey(publicKey: Bytes) {
   return base58.encode(publicKey);
 }
 
+export function getPublicKeyFromAddress(address: string) {
+  return base58.decode(address);
+}
+
 type PrivateKeyFormat = 'base58' | 'hex' | 'array';
 
 export function formatPrivate(privateKey: Bytes, format: PrivateKeyFormat = 'base58') {


### PR DESCRIPTION
`getPublicKeyFromAddress` method is helpful for actions like metadata address generation:

```js
function metadataAddress(mint) {
  return sol.programAddress('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
    utf8.decode('metadata'),
    sol.getPublicKeyFromAddress('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'),
    sol.getPublicKeyFromAddress(mint));
}
```